### PR TITLE
Create the install dir, use PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ clean:
 	rm -rf hterm
 
 install:
-	cp ./hterm $(DESTDIR)/bin
+	@mkdir -p $(DESTDIR)$(PREFIX)/bin/
+	cp ./hterm $(DESTDIR)$(PREFIX)/bin/
 
 deb: 
 	tar czvf ../hterm_0.0.1.orig.tar.gz ../hackterm

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,9 @@
 %:
 	dh $@
 
+override_dh_auto_install:
+	dh_auto_install -- PREFIX=/usr
+
 override_dh_install:
 	sed -i "/dependency_libs/ s/'.*'/''/" `find . -name '*.la'`
 	dh_install


### PR DESCRIPTION
I tried installing the deb package from your website but got the following error:

``` bash
dpkg: error processing ~/downloads/hterm_0.0.1-1_amd64.deb (--install):
 trying to overwrite directory '/bin' in package
```

Looking at the files in the package shows why

``` bash
% dpkg -c ~/downloads/hterm_0.0.1-1_amd64.deb
drwxr-xr-x root/root         0 2013-05-01 00:41 ./
drwxr-xr-x root/root         0 2013-05-01 00:41 ./usr/
drwxr-xr-x root/root         0 2013-05-01 00:41 ./usr/share/
drwxr-xr-x root/root         0 2013-05-01 00:41 ./usr/share/doc/
drwxr-xr-x root/root         0 2013-05-01 00:41 ./usr/share/doc/hterm/
-rw-r--r-- root/root         0 2013-04-30 23:59 ./usr/share/doc/hterm/copyright
-rw-r--r-- root/root       149 2013-04-30 23:59 ./usr/share/doc/hterm/changelog.Debian.gz
-rwxr-xr-x root/root   3880288 2013-05-01 00:41 ./bin
```

The hterm binary is named 'bin' and as such conflicts with the directory structure.

I tracked it down to how `debuild` was using `make install` when building the package. I added a `mkdir` to the install target in the Makefile. I also set it to use the PREFIX variable to allow controlling where it is installed. 

The built package now looks like

``` bash
% dpkg -c ../hterm_0.0.1-1_amd64.deb 
drwxr-xr-x root/root         0 2013-05-11 16:30 ./
drwxr-xr-x root/root         0 2013-05-11 16:30 ./usr/
drwxr-xr-x root/root         0 2013-05-11 16:30 ./usr/bin/
-rwxr-xr-x root/root   3810520 2013-05-11 16:30 ./usr/bin/hterm
drwxr-xr-x root/root         0 2013-05-11 16:30 ./usr/share/
drwxr-xr-x root/root         0 2013-05-11 16:30 ./usr/share/doc/
drwxr-xr-x root/root         0 2013-05-11 16:30 ./usr/share/doc/hterm/
-rw-r--r-- root/root       149 2013-05-11 16:22 ./usr/share/doc/hterm/changelog.Debian.gz
-rw-r--r-- root/root         0 2013-05-11 16:22 ./usr/share/doc/hterm/copyright
```
